### PR TITLE
Mutation queue

### DIFF
--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "check-types": "tsc -noEmit",
-    "prepublish": "tsc -noEmit && vite build",
+    "prepublish": "tsc -noEmit && vite build && terser ./dist/record.js --compress -o ./dist/record.min.js",
     "lint": "yarn eslint src/**/*.ts"
   },
   "homepage": "https://github.com/rrweb-io/rrweb/tree/main/packages/@rrweb/record#readme",
@@ -48,16 +48,18 @@
     "package.json"
   ],
   "devDependencies": {
+    "@rollup/plugin-terser": "0.4.4",
     "puppeteer": "^20.9.0",
+    "terser": "^5.44.0",
+    "typescript": "^5.4.5",
     "vite": "^5.3.1",
     "vite-plugin-dts": "^3.9.1",
-    "vitest": "^1.4.0",
-    "typescript": "^5.4.5"
+    "vitest": "^1.4.0"
   },
   "dependencies": {
     "@rrweb/types": "^2.0.0-alpha.18",
-    "rrweb": "^2.0.0-alpha.18",
-    "@rrweb/utils": "^2.0.0-alpha.18"
+    "@rrweb/utils": "^2.0.0-alpha.18",
+    "rrweb": "^2.0.0-alpha.18"
   },
   "browserslist": [
     "supports es6-class"

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -12,7 +12,7 @@ export class AutoProcessMutationQueue {
 
   constructor({
     processFunction,
-    processBatch = 10_000,
+    processBatch = 5_000,
   }: {
     processBatch?: number;
     processFunction: ProcessFunction;
@@ -29,7 +29,6 @@ export class AutoProcessMutationQueue {
     mutations.forEach((m) =>
       this.store.push(typeof m === 'function' ? m : [m, nowTimestamp()]),
     );
-    this.start();
     this.process();
   }
 
@@ -47,6 +46,8 @@ export class AutoProcessMutationQueue {
     );
     if (!this.store.length) {
       this.stop();
+    } else if (!this.interval) {
+      this.start();
     }
   }
 

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -44,15 +44,22 @@ export class AutoProcessMutationQueue {
     records.forEach((record: ProcessItem) =>
       typeof record === 'function' ? record() : this.processFunction(record),
     );
-    if (!this.store.length) {
+    // console.log('processing', records.length, 'of', this.store.length);
+    if (!this.store.length && this.interval) {
+      // console.log('stopping poll');
       this.stop();
     } else if (!this.interval) {
+      // console.log('starting poll');
       this.start();
     }
   }
 
   getFirstMutation() {
     return this.store.find((i) => typeof i !== 'function');
+  }
+
+  shouldPoll() {
+    return this.store.length && !this.interval;
   }
 
   start(t = 100): void {

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -7,7 +7,7 @@ export class AutoProcessMutationQueue {
   private store: ProcessItem[] = [];
   private processBatch: number;
   private processFunction: ProcessFunction;
-  private interval?: number;
+  private interval?: ReturnType<typeof setInterval>;
 
   constructor({
     processFunction,
@@ -29,7 +29,7 @@ export class AutoProcessMutationQueue {
     this.process();
   }
 
-  dequeue(n?: number = this.processBatch): ProcessItem[] {
+  dequeue(n: number = this.processBatch): ProcessItem[] {
     if (this.store.length) {
       return this.store.splice(0, n);
     }
@@ -52,6 +52,7 @@ export class AutoProcessMutationQueue {
   stop(): void {
     if (this.interval) {
       clearInterval(this.interval);
+      this.interval = undefined;
     }
   }
 }

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -1,0 +1,57 @@
+import type { mutationRecord } from '@rrweb/types';
+
+type ProcessFunction = (mutation: mutationRecord) => void;
+type ProcessItem = mutationRecord | (() => void);
+
+export class AutoProcessMutationQueue {
+  private store: ProcessItem[] = [];
+  private processBatch: number;
+  private processFunction: ProcessFunction;
+  private interval?: number;
+
+  constructor({
+    processFunction,
+    processBatch = 10_000,
+  }: {
+    processBatch?: number;
+    processFunction: ProcessFunction;
+  }) {
+    this.processBatch = processBatch;
+    this.processFunction = processFunction;
+  }
+
+  get size() {
+    return this.store.length;
+  }
+
+  enqueue(mutations: ProcessItem[]): void {
+    this.store.push(...mutations);
+    this.process();
+  }
+
+  dequeue(n?: number = this.processBatch): ProcessItem[] {
+    if (this.store.length) {
+      return this.store.splice(0, n);
+    }
+    return [];
+  }
+
+  process(): void {
+    const records = this.dequeue();
+    records.forEach((record: ProcessItem) =>
+      typeof record === 'function' ? record() : this.processFunction(record),
+    );
+  }
+
+  start(t = 100): void {
+    this.interval = setInterval(() => {
+      this.process();
+    }, t);
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+}

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -1,26 +1,30 @@
 import type { mutationRecord } from '@rrweb/types';
 import { nowTimestamp } from '../utils';
 
-type ProcessFunction = (mutation: ProcessItem) => void;
-type ProcessItem = [mutationRecord, timestamp: number] | (() => void);
+type ProcessFunction = (mutation: mutationRecord) => void;
+type MutationItem = {
+  mutationRecord: mutationRecord;
+  timestamp: number;
+};
+type ProcessItem = MutationItem | (() => void);
 
 export class AutoProcessMutationQueue {
   private store: ProcessItem[] = [];
-  private processBatch: number;
+  private batchSize: number;
   private batchInterval: number;
   private processFunction: ProcessFunction;
   private interval?: ReturnType<typeof setInterval>;
 
   constructor({
     processFunction,
-    processBatch = 5_000,
+    batchSize = 5_000,
     batchInterval = 100,
   }: {
-    processBatch?: number;
+    batchSize?: number;
     processFunction: ProcessFunction;
     batchInterval?: number;
   }) {
-    this.processBatch = processBatch;
+    this.batchSize = batchSize;
     this.processFunction = processFunction;
     this.batchInterval = batchInterval;
   }
@@ -31,12 +35,16 @@ export class AutoProcessMutationQueue {
 
   enqueue(mutations: (mutationRecord | (() => void))[]): void {
     mutations.forEach((m) =>
-      this.store.push(typeof m === 'function' ? m : [m, nowTimestamp()]),
+      this.store.push(
+        typeof m === 'function'
+          ? m
+          : { mutationRecord: m, timestamp: nowTimestamp() },
+      ),
     );
     this.process();
   }
 
-  dequeue(n: number = this.processBatch): ProcessItem[] {
+  dequeue(n: number = this.batchSize): ProcessItem[] {
     if (this.store.length) {
       return this.store.splice(0, n);
     }
@@ -46,7 +54,9 @@ export class AutoProcessMutationQueue {
   process(): void {
     const records = this.dequeue();
     records.forEach((record: ProcessItem) =>
-      typeof record === 'function' ? record() : this.processFunction(record),
+      typeof record === 'function'
+        ? record()
+        : this.processFunction(record.mutationRecord),
     );
     if (!this.store.length && this.interval) {
       this.stop();
@@ -55,8 +65,8 @@ export class AutoProcessMutationQueue {
     }
   }
 
-  getFirstMutation() {
-    return this.store.find((i) => typeof i !== 'function');
+  getFirstMutation(): MutationItem | undefined {
+    return this.store.find((i): i is MutationItem => typeof i !== 'function');
   }
 
   shouldPoll() {

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -1,7 +1,8 @@
 import type { mutationRecord } from '@rrweb/types';
+import { nowTimestamp } from '../utils';
 
-type ProcessFunction = (mutation: mutationRecord) => void;
-type ProcessItem = mutationRecord | (() => void);
+type ProcessFunction = (mutation: ProcessItem) => void;
+type ProcessItem = [mutationRecord, timestamp: number] | (() => void);
 
 export class AutoProcessMutationQueue {
   private store: ProcessItem[] = [];
@@ -24,8 +25,10 @@ export class AutoProcessMutationQueue {
     return this.store.length;
   }
 
-  enqueue(mutations: ProcessItem[]): void {
-    this.store.push(...mutations);
+  enqueue(mutations: (mutationRecord | (() => void))[]): void {
+    mutations.forEach((m) =>
+      this.store.push(typeof m === 'function' ? m : [m, nowTimestamp()]),
+    );
     this.process();
   }
 
@@ -41,6 +44,10 @@ export class AutoProcessMutationQueue {
     records.forEach((record: ProcessItem) =>
       typeof record === 'function' ? record() : this.processFunction(record),
     );
+  }
+
+  getFirstMutation() {
+    return this.store.find((i) => typeof i !== 'function');
   }
 
   start(t = 100): void {

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -44,12 +44,9 @@ export class AutoProcessMutationQueue {
     records.forEach((record: ProcessItem) =>
       typeof record === 'function' ? record() : this.processFunction(record),
     );
-    // console.log('processing', records.length, 'of', this.store.length);
     if (!this.store.length && this.interval) {
-      // console.log('stopping poll');
       this.stop();
     } else if (!this.interval) {
-      // console.log('starting poll');
       this.start();
     }
   }

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -7,18 +7,22 @@ type ProcessItem = [mutationRecord, timestamp: number] | (() => void);
 export class AutoProcessMutationQueue {
   private store: ProcessItem[] = [];
   private processBatch: number;
+  private batchInterval: number;
   private processFunction: ProcessFunction;
   private interval?: ReturnType<typeof setInterval>;
 
   constructor({
     processFunction,
     processBatch = 5_000,
+    batchInterval = 100,
   }: {
     processBatch?: number;
     processFunction: ProcessFunction;
+    batchInterval?: number;
   }) {
     this.processBatch = processBatch;
     this.processFunction = processFunction;
+    this.batchInterval = batchInterval;
   }
 
   get size() {
@@ -59,10 +63,10 @@ export class AutoProcessMutationQueue {
     return this.store.length && !this.interval;
   }
 
-  start(t = 100): void {
+  start(): void {
     this.interval = setInterval(() => {
       this.process();
-    }, t);
+    }, this.batchInterval);
   }
 
   stop(): void {

--- a/packages/rrweb/src/record/auto-process-mutation-queue.ts
+++ b/packages/rrweb/src/record/auto-process-mutation-queue.ts
@@ -29,6 +29,7 @@ export class AutoProcessMutationQueue {
     mutations.forEach((m) =>
       this.store.push(typeof m === 'function' ? m : [m, nowTimestamp()]),
     );
+    this.start();
     this.process();
   }
 
@@ -44,6 +45,9 @@ export class AutoProcessMutationQueue {
     records.forEach((record: ProcessItem) =>
       typeof record === 'function' ? record() : this.processFunction(record),
     );
+    if (!this.store.length) {
+      this.stop();
+    }
   }
 
   getFirstMutation() {

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -99,6 +99,8 @@ function record<T = eventWithTime>(
     keepIframeSrcFn = () => false,
     ignoreCSSAttributes = new Set([]),
     errorHandler,
+    mutationQueueBatchSize,
+    mutationQueueBatchInterval,
   } = options;
 
   registerErrorHandler(errorHandler);
@@ -556,6 +558,8 @@ function record<T = eventWithTime>(
           processedNodeManager,
           canvasManager,
           ignoreCSSAttributes,
+          mutationQueueBatchSize,
+          mutationQueueBatchInterval,
           plugins:
             plugins
               ?.filter((p) => p.observer)

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -101,6 +101,7 @@ function record<T = eventWithTime>(
     errorHandler,
     mutationQueueBatchSize,
     mutationQueueBatchInterval,
+    mutationQueueEnabled,
   } = options;
 
   registerErrorHandler(errorHandler);
@@ -560,6 +561,7 @@ function record<T = eventWithTime>(
           ignoreCSSAttributes,
           mutationQueueBatchSize,
           mutationQueueBatchInterval,
+          mutationQueueEnabled,
           plugins:
             plugins
               ?.filter((p) => p.observer)

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -201,9 +201,12 @@ function record<T = eventWithTime>(
     }
     return e as unknown as T;
   };
-  wrappedEmit = (r: eventWithoutTime, isCheckout?: boolean) => {
+  wrappedEmit = (
+    r: eventWithoutTime & { timestamp?: number },
+    isCheckout?: boolean,
+  ) => {
     const e = r as eventWithTime;
-    e.timestamp = nowTimestamp();
+    e.timestamp = e.timestamp ?? nowTimestamp();
     if (
       mutationBuffers[0]?.isFrozen() &&
       e.type !== EventType.FullSnapshot &&
@@ -668,6 +671,16 @@ record.takeFullSnapshot = (isCheckout?: boolean) => {
     throw new Error('please take full snapshot after start recording');
   }
   takeFullSnapshot(isCheckout);
+};
+
+record.areBuffersEmpty = () => {
+  return mutationBuffers.some((buf) => buf.isQueueEmpty);
+};
+
+record.hasPendingMutationsBeforeTs = (timestamp: number) => {
+  return mutationBuffers.some((buf) =>
+    buf.hasQueuedMutationBeforeTs(timestamp),
+  );
 };
 
 record.mirror = mirror;

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -33,6 +33,7 @@ import {
   closestElementOfNode,
 } from '../utils';
 import dom from '@rrweb/utils';
+import { AutoProcessMutationQueue } from './auto-process-mutation-queue';
 
 type DoubleLinkedListNode = {
   previous: DoubleLinkedListNode | null;
@@ -193,6 +194,13 @@ export default class MutationBuffer {
   private canvasManager: observerParam['canvasManager'];
   private processedNodeManager: observerParam['processedNodeManager'];
   private unattachedDoc: HTMLDocument;
+  private mutationQueue: AutoProcessMutationQueue;
+
+  constructor() {
+    this.mutationQueue = new AutoProcessMutationQueue({
+      processFunction: this.processMutation,
+    });
+  }
 
   public init(options: MutationBufferParam) {
     (
@@ -223,6 +231,8 @@ export default class MutationBuffer {
       // just a type trick, the runtime result is correct
       this[key] = options[key] as never;
     });
+
+    this.mutationQueue.start();
   }
 
   public freeze() {
@@ -257,8 +267,7 @@ export default class MutationBuffer {
   }
 
   public processMutations = (mutations: mutationRecord[]) => {
-    mutations.forEach(this.processMutation); // adds mutations to the buffer
-    this.emit(); // clears buffer if not locked/frozen
+    this.mutationQueue.enqueue([...mutations, this.emit]);
   };
 
   public emit = () => {

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -195,18 +195,8 @@ export default class MutationBuffer {
   private processedNodeManager: observerParam['processedNodeManager'];
   private unattachedDoc: HTMLDocument;
   private mutationQueue: AutoProcessMutationQueue;
-  private timestamps = {
-    adds: [],
-    texts: [],
-    removes: [],
-    attributes: [],
-  };
-
-  constructor() {
-    this.mutationQueue = new AutoProcessMutationQueue({
-      processFunction: this.processMutation,
-    });
-  }
+  private mutationQueueBatchSize?: number;
+  private mutationQueueBatchInterval?: number;
 
   public init(options: MutationBufferParam) {
     (
@@ -238,6 +228,12 @@ export default class MutationBuffer {
     ).forEach((key) => {
       // just a type trick, the runtime result is correct
       this[key] = options[key] as never;
+    });
+
+    this.mutationQueue = new AutoProcessMutationQueue({
+      processFunction: this.processMutation,
+      batchSize: this.mutationQueueBatchSize,
+      batchInterval: this.mutationQueueBatchInterval,
     });
   }
 
@@ -285,7 +281,7 @@ export default class MutationBuffer {
     if (!mutation) {
       return false;
     }
-    return mutation[1] < timestamp;
+    return mutation.timestamp < timestamp;
   };
 
   public emit = () => {
@@ -477,20 +473,16 @@ export default class MutationBuffer {
 
     const payload = {
       texts: this.texts
-        .map((text, idx) => {
+        .map((text) => {
           const n = text.node;
           const parent = dom.parentNode(n);
           if (parent && (parent as Element).tagName === 'TEXTAREA') {
             // the node is being ignored as it isn't in the mirror, so shift mutation to attributes on parent textarea
-            this.genTextAreaValueMutation(
-              parent as HTMLTextAreaElement,
-              this.timestamps.texts[idx],
-            );
+            this.genTextAreaValueMutation(parent as HTMLTextAreaElement);
           }
           return {
             id: this.mirror.getId(n),
             value: text.value,
-            timestamp: this.timestamps.texts[idx],
           };
         })
         // no need to include them on added elements, as they have just been serialized with up to date attribubtes
@@ -498,7 +490,7 @@ export default class MutationBuffer {
         // text mutation's id was not in the mirror map means the target node has been removed
         .filter((text) => this.mirror.has(text.id)),
       attributes: this.attributes
-        .map((attribute, idx) => {
+        .map((attribute) => {
           const { attributes } = attribute;
           if (typeof attributes.style === 'string') {
             const diffAsStr = JSON.stringify(attribute.styleDiff);
@@ -519,16 +511,14 @@ export default class MutationBuffer {
           return {
             id: this.mirror.getId(attribute.node),
             attributes: attributes,
-            timestamp: this.timestamps.attributes[idx],
           };
         })
         // no need to include them on added elements, as they have just been serialized with up to date attribubtes
         .filter((attribute) => !addedIds.has(attribute.id))
         // attribute mutation's id was not in the mirror map means the target node has been removed
         .filter((attribute) => this.mirror.has(attribute.id)),
-      removes: this.removes.map((remove, idx) => ({
+      removes: this.removes.map((remove) => ({
         ...remove,
-        timestamp: this.timestamps.removes[idx],
       })),
       adds,
     };
@@ -552,20 +542,11 @@ export default class MutationBuffer {
     this.droppedSet = new Set<Node>();
     this.removesSubTreeCache = new Set<Node>();
     this.movedMap = {};
-    this.timestamps = {
-      adds: [],
-      texts: [],
-      removes: [],
-      attributes: [],
-    };
 
     this.mutationCb(payload);
   };
 
-  private genTextAreaValueMutation = (
-    textarea: HTMLTextAreaElement,
-    timestamp: number,
-  ) => {
+  private genTextAreaValueMutation = (textarea: HTMLTextAreaElement) => {
     let item = this.attributeMap.get(textarea);
     if (!item) {
       item = {
@@ -575,7 +556,6 @@ export default class MutationBuffer {
         _unchangedStyles: {},
       };
       this.attributes.push(item);
-      this.timestamps.attributes.push(timestamp);
       this.attributeMap.set(textarea, item);
     }
     const value = Array.from(
@@ -592,10 +572,7 @@ export default class MutationBuffer {
     });
   };
 
-  private processMutation = ([m, timestamp]: [
-    m: mutationRecord,
-    timestamp: number,
-  ]) => {
+  private processMutation = (m: mutationRecord) => {
     if (isIgnored(m.target, this.mirror, this.slimDOMOptions)) {
       return;
     }
@@ -621,7 +598,6 @@ export default class MutationBuffer {
                 : value,
             node: m.target,
           });
-          this.timestamps.texts.push(timestamp);
         }
         break;
       }
@@ -672,7 +648,6 @@ export default class MutationBuffer {
           };
           this.attributes.push(item);
           this.attributeMap.set(m.target, item);
-          this.timestamps.attributes.push(timestamp);
         }
 
         // Keep this property on inputs that used to be password inputs
@@ -750,10 +725,7 @@ export default class MutationBuffer {
 
         if ((m.target as Element).tagName === 'TEXTAREA') {
           // children would be ignored in genAdds as they aren't in the mirror
-          this.genTextAreaValueMutation(
-            m.target as HTMLTextAreaElement,
-            timestamp,
-          );
+          this.genTextAreaValueMutation(m.target as HTMLTextAreaElement);
           return; // any removedNodes won't have been in mirror either
         }
 
@@ -803,7 +775,6 @@ export default class MutationBuffer {
                   ? true
                   : undefined,
             });
-            this.timestamps.removes.push(timestamp);
             processRemoves(n, this.removesSubTreeCache);
           }
           this.mapRemoves.push(n);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -284,8 +284,7 @@ export default class MutationBuffer {
     if (!mutation) {
       return false;
     }
-    // console.log(mutation, timestamp);
-    return false;
+    return mutation[1] < timestamp;
   };
 
   public emit = () => {

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import {
   serializeNodeWithId,
   transformAttribute,
@@ -195,6 +196,12 @@ export default class MutationBuffer {
   private processedNodeManager: observerParam['processedNodeManager'];
   private unattachedDoc: HTMLDocument;
   private mutationQueue: AutoProcessMutationQueue;
+  private timestamps = {
+    adds: [],
+    texts: [],
+    removes: [],
+    attributes: [],
+  };
 
   constructor() {
     this.mutationQueue = new AutoProcessMutationQueue({
@@ -268,6 +275,19 @@ export default class MutationBuffer {
 
   public processMutations = (mutations: mutationRecord[]) => {
     this.mutationQueue.enqueue([...mutations, this.emit]);
+  };
+
+  public isQueueEmpty = (): boolean => {
+    return this.mutationQueue.size === 0;
+  };
+
+  public hasQueuedMutationBeforeTs = (timestamp: number) => {
+    const mutation = this.mutationQueue.getFirstMutation();
+    if (!mutation) {
+      return false;
+    }
+    console.log(mutation, timestamp);
+    return false;
   };
 
   public emit = () => {
@@ -459,16 +479,20 @@ export default class MutationBuffer {
 
     const payload = {
       texts: this.texts
-        .map((text) => {
+        .map((text, idx) => {
           const n = text.node;
           const parent = dom.parentNode(n);
           if (parent && (parent as Element).tagName === 'TEXTAREA') {
             // the node is being ignored as it isn't in the mirror, so shift mutation to attributes on parent textarea
-            this.genTextAreaValueMutation(parent as HTMLTextAreaElement);
+            this.genTextAreaValueMutation(
+              parent as HTMLTextAreaElement,
+              this.timestamps.texts[idx],
+            );
           }
           return {
             id: this.mirror.getId(n),
             value: text.value,
+            timestamp: this.timestamps.texts[idx],
           };
         })
         // no need to include them on added elements, as they have just been serialized with up to date attribubtes
@@ -476,7 +500,7 @@ export default class MutationBuffer {
         // text mutation's id was not in the mirror map means the target node has been removed
         .filter((text) => this.mirror.has(text.id)),
       attributes: this.attributes
-        .map((attribute) => {
+        .map((attribute, idx) => {
           const { attributes } = attribute;
           if (typeof attributes.style === 'string') {
             const diffAsStr = JSON.stringify(attribute.styleDiff);
@@ -497,13 +521,17 @@ export default class MutationBuffer {
           return {
             id: this.mirror.getId(attribute.node),
             attributes: attributes,
+            timestamp: this.timestamps.attributes[idx],
           };
         })
         // no need to include them on added elements, as they have just been serialized with up to date attribubtes
         .filter((attribute) => !addedIds.has(attribute.id))
         // attribute mutation's id was not in the mirror map means the target node has been removed
         .filter((attribute) => this.mirror.has(attribute.id)),
-      removes: this.removes,
+      removes: this.removes.map((remove, idx) => ({
+        ...remove,
+        timestamp: this.timestamps.removes[idx],
+      })),
       adds,
     };
     // payload may be empty if the mutations happened in some blocked elements
@@ -526,11 +554,20 @@ export default class MutationBuffer {
     this.droppedSet = new Set<Node>();
     this.removesSubTreeCache = new Set<Node>();
     this.movedMap = {};
+    this.timestamps = {
+      adds: [],
+      texts: [],
+      removes: [],
+      attributes: [],
+    };
 
     this.mutationCb(payload);
   };
 
-  private genTextAreaValueMutation = (textarea: HTMLTextAreaElement) => {
+  private genTextAreaValueMutation = (
+    textarea: HTMLTextAreaElement,
+    timestamp: number,
+  ) => {
     let item = this.attributeMap.get(textarea);
     if (!item) {
       item = {
@@ -540,6 +577,7 @@ export default class MutationBuffer {
         _unchangedStyles: {},
       };
       this.attributes.push(item);
+      this.timestamps.attributes.push(timestamp);
       this.attributeMap.set(textarea, item);
     }
     const value = Array.from(
@@ -556,7 +594,10 @@ export default class MutationBuffer {
     });
   };
 
-  private processMutation = (m: mutationRecord) => {
+  private processMutation = ([m, timestamp]: [
+    m: mutationRecord,
+    timestamp: number,
+  ]) => {
     if (isIgnored(m.target, this.mirror, this.slimDOMOptions)) {
       return;
     }
@@ -582,6 +623,7 @@ export default class MutationBuffer {
                 : value,
             node: m.target,
           });
+          this.timestamps.texts.push(timestamp);
         }
         break;
       }
@@ -632,6 +674,7 @@ export default class MutationBuffer {
           };
           this.attributes.push(item);
           this.attributeMap.set(m.target, item);
+          this.timestamps.attributes.push(timestamp);
         }
 
         // Keep this property on inputs that used to be password inputs
@@ -709,7 +752,10 @@ export default class MutationBuffer {
 
         if ((m.target as Element).tagName === 'TEXTAREA') {
           // children would be ignored in genAdds as they aren't in the mirror
-          this.genTextAreaValueMutation(m.target as HTMLTextAreaElement);
+          this.genTextAreaValueMutation(
+            m.target as HTMLTextAreaElement,
+            timestamp,
+          );
           return; // any removedNodes won't have been in mirror either
         }
 
@@ -759,6 +805,7 @@ export default class MutationBuffer {
                   ? true
                   : undefined,
             });
+            this.timestamps.removes.push(timestamp);
             processRemoves(n, this.removesSubTreeCache);
           }
           this.mapRemoves.push(n);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -233,6 +233,8 @@ export default class MutationBuffer {
         'shadowDomManager',
         'canvasManager',
         'processedNodeManager',
+        'mutationQueueBatchSize',
+        'mutationQueueBatchInterval',
       ] as const
     ).forEach((key) => {
       // just a type trick, the runtime result is correct

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -271,7 +271,7 @@ export default class MutationBuffer {
   }
 
   public processMutations = (mutations: mutationRecord[]) => {
-    if (mutationQueueEnabled) {
+    if (this.mutationQueueEnabled) {
       this.mutationQueue.enqueue([...mutations, this.emit]);
     } else {
       mutations.forEach(this.processMutation);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -284,7 +284,7 @@ export default class MutationBuffer {
     if (!mutation) {
       return false;
     }
-    console.log(mutation, timestamp);
+    // console.log(mutation, timestamp);
     return false;
   };
 

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   serializeNodeWithId,
   transformAttribute,

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -197,6 +197,7 @@ export default class MutationBuffer {
   private mutationQueue: AutoProcessMutationQueue;
   private mutationQueueBatchSize?: number;
   private mutationQueueBatchInterval?: number;
+  private mutationQueueEnabled: boolean;
 
   public init(options: MutationBufferParam) {
     (
@@ -224,6 +225,7 @@ export default class MutationBuffer {
         'processedNodeManager',
         'mutationQueueBatchSize',
         'mutationQueueBatchInterval',
+        'mutationQueueEnabled',
       ] as const
     ).forEach((key) => {
       // just a type trick, the runtime result is correct
@@ -269,7 +271,11 @@ export default class MutationBuffer {
   }
 
   public processMutations = (mutations: mutationRecord[]) => {
-    this.mutationQueue.enqueue([...mutations, this.emit]);
+    if (mutationQueueEnabled) {
+      this.mutationQueue.enqueue([...mutations, this.emit]);
+    } else {
+      mutations.forEach(this.processMutation);
+    }
   };
 
   public isQueueEmpty = (): boolean => {

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -238,8 +238,6 @@ export default class MutationBuffer {
       // just a type trick, the runtime result is correct
       this[key] = options[key] as never;
     });
-
-    this.mutationQueue.start();
   }
 
   public freeze() {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -85,6 +85,7 @@ export function initMutationObserver(
   const mutationBuffer = new MutationBuffer();
   mutationBuffers.push(mutationBuffer);
   // see mutation.ts for details
+  console.log(options);
   mutationBuffer.init(options);
   const observer = new (mutationObserverCtor() as new (
     callback: MutationCallback,

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -85,7 +85,6 @@ export function initMutationObserver(
   const mutationBuffer = new MutationBuffer();
   mutationBuffers.push(mutationBuffer);
   // see mutation.ts for details
-  console.log(options);
   mutationBuffer.init(options);
   const observer = new (mutationObserverCtor() as new (
     callback: MutationCallback,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -126,6 +126,8 @@ export type observerParam = {
     callback: (...arg: Array<unknown>) => void;
     options: unknown;
   }>;
+  mutationQueueBatchSize?: number;
+  mutationQueueBatchInterval?: number;
 };
 
 export type MutationBufferParam = Pick<
@@ -151,6 +153,8 @@ export type MutationBufferParam = Pick<
   | 'shadowDomManager'
   | 'canvasManager'
   | 'processedNodeManager'
+  | 'mutationQueueBatchSize'
+  | 'mutationQueueBatchInterval'
 >;
 
 export type ReplayPlugin = {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -74,6 +74,8 @@ export type recordOptions<T> = {
   mousemoveWait?: number;
   keepIframeSrcFn?: KeepIframeSrcFn;
   errorHandler?: ErrorHandler;
+  mutationQueueBatchSize?: number;
+  mutationQueueBatchInterval?: number;
 };
 
 export type observerParam = {

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -76,6 +76,7 @@ export type recordOptions<T> = {
   errorHandler?: ErrorHandler;
   mutationQueueBatchSize?: number;
   mutationQueueBatchInterval?: number;
+  mutationQueueEnabled?: boolean;
 };
 
 export type observerParam = {
@@ -130,6 +131,7 @@ export type observerParam = {
   }>;
   mutationQueueBatchSize?: number;
   mutationQueueBatchInterval?: number;
+  mutationQueueEnabled?: boolean;
 };
 
 export type MutationBufferParam = Pick<
@@ -157,6 +159,7 @@ export type MutationBufferParam = Pick<
   | 'processedNodeManager'
   | 'mutationQueueBatchSize'
   | 'mutationQueueBatchInterval'
+  | 'mutationQueueEnabled'
 >;
 
 export type ReplayPlugin = {


### PR DESCRIPTION
Adds a queue to push mutation events to, these mutations will be processed in batches at configurable intervals to ensure that a single click causing thousands of mutations (e.g. changing themes) does not block the repainting of the screen.